### PR TITLE
Use the same capitalisation rules across all files; other small fixes

### DIFF
--- a/0x00-0x0F.md
+++ b/0x00-0x0F.md
@@ -18,19 +18,19 @@
 
 ## 0x04
 
-- Reserved for Hs-mode controller
+- Reserved for HS-mode controller
 
 ## 0x05
 
-- Reserved for Hs-mode controller
+- Reserved for HS-mode controller
 
 ## 0x06
 
-- Reserved for Hs-mode controller
+- Reserved for HS-mode controller
 
 ## 0x07
 
-- Reserved for Hs-mode controller
+- Reserved for HS-mode controller
 
 ## 0x0B
 

--- a/0x00-0x0F.md
+++ b/0x00-0x0F.md
@@ -2,35 +2,35 @@
 
 ## 0x00
 
-- Reserved - General Call Address
+- Reserved - general call address
 
 ## 0x01
 
-- Reserved for CBUS Compatibility
+- Reserved for CBUS compatibility
 
 ## 0x02
 
-- Reserved for I2C-compatible Bus Variants
+- Reserved for I2C-compatible bus variants
 
 ## 0x03
 
-- Reserved for Future Use
+- Reserved for future use
 
 ## 0x04
 
-- Reserved for Hs-mode Controller
+- Reserved for Hs-mode controller
 
 ## 0x05
 
-- Reserved for Hs-mode Controller
+- Reserved for Hs-mode controller
 
 ## 0x06
 
-- Reserved for Hs-mode Controller
+- Reserved for Hs-mode controller
 
 ## 0x07
 
-- Reserved for Hs-mode Controller
+- Reserved for Hs-mode controller
 
 ## 0x0B
 

--- a/0x10-0x1F.md
+++ b/0x10-0x1F.md
@@ -2,8 +2,8 @@
 
 ## 0x10
 
-- VEML6075 UV sensor (0x10 only)
-- [VEML7700 Ambient Light sensor](https://www.adafruit.com/product/4162) (0x10 only)
+- VEML6075 UV Sensor (0x10 only)
+- [VEML7700 Ambient Light Sensor](https://www.adafruit.com/product/4162) (0x10 only)
 
 ## 0x11
 
@@ -15,47 +15,47 @@
 
 ## 0x13
 
-- [VCNL40x0 proximity sensor](https://www.adafruit.com/product/466) (0x13 only)
+- [VCNL40x0 Proximity Sensor](https://www.adafruit.com/product/466) (0x13 only)
 
 ## 0x18
 
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
-- [MPRLS Pressure sensor](https://www.adafruit.com/product/3965) (0x18)
-- [LIS331 3-axis accelerometer](https://www.adafruit.com/product/4626) (0x18 or 0x19)
-- [LIS3DH 3-axis accelerometer](https://www.adafruit.com/product/2809) (0x18 or 0x19)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [MPRLS Pressure Sensor](https://www.adafruit.com/product/3965) (0x18)
+- [LIS331 3-Axis Accelerometer](https://www.adafruit.com/product/4626) (0x18 or 0x19)
+- [LIS3DH 3-Axis Accelerometer](https://www.adafruit.com/product/2809) (0x18 or 0x19)
 
 ## 0x19
 
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
-- [LIS331 3-axis accelerometer](https://www.adafruit.com/product/4626) (0x18 or 0x19)
-- [LIS3DH 3-axis accelerometer](https://www.adafruit.com/product/2809) (0x18 or 0x19)
-- [LSM303 Accelerometer & Magnetometer](https://www.adafruit.com/product/4413) (0x19 for accelerometer and 0x1E for magnetometer)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [LIS331 3-Axis Accelerometer](https://www.adafruit.com/product/4626) (0x18 or 0x19)
+- [LIS3DH 3-Axis Accelerometer](https://www.adafruit.com/product/2809) (0x18 or 0x19)
+- [LSM303 Accelerometer/Magnetometer](https://www.adafruit.com/product/4413) (0x19 for accelerometer and 0x1E for magnetometer)
 
 ## 0x1A
 
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
 
 ## 0x1B
 
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
 
 ## 0x1C
 
 - [LIS3MDL Magetometer](https://www.adafruit.com/product/4479) (0x1C & 0x1E)
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
-- [MMA845x 3-axis Accelerometer](https://www.adafruit.com/product/2019) (0x1C or 0x1D)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [MMA845x 3-Axis Accelerometer](https://www.adafruit.com/product/2019) (0x1C or 0x1D)
 - [FXOS8700 Accelerometer/Magnetometer](https://www.adafruit.com/product/3463) (0x1C, 0x1D, 0x1E or 0x1F)
 - MMA7455L (0x1C or 0x1D)
 
 ## 0x1D
 
-- [ADXL343 3-axis accelerometer](https://www.adafruit.com/product/4097) (0x1D or 0x53)
-- [ADXL345 3-axis accelerometer](https://www.adafruit.com/product/1231) (0x1D or 0x53)
+- [ADXL343 3-Axis Accelerometer](https://www.adafruit.com/product/4097) (0x1D or 0x53)
+- [ADXL345 3-Axis Accelerometer](https://www.adafruit.com/product/1231) (0x1D or 0x53)
 - [FXOS8700 Accelerometer/Magnetometer](https://www.adafruit.com/product/3463) (0x1C, 0x1D, 0x1E or 0x1F)
-- [LSM9DS0 9-axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [LSM9DS0 9-Axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
 - MMA7455L (0x1C or 0x1D)
-- [MMA845x 3-axis Accelerometer](https://www.adafruit.com/product/2019) (0x1C or 0x1D)
+- [MMA845x 3-Axis Accelerometer](https://www.adafruit.com/product/2019) (0x1C or 0x1D)
 
 ## 0x1E
 
@@ -63,11 +63,11 @@
 - [HMC5883 Magnetometer](https://www.adafruit.com/product/1746) (0x1E only)
 - [LIS2MDL Magnetometer](https://www.adafruit.com/product/4488) (0x1E only)
 - [LIS3MDL Magnetometer](https://www.adafruit.com/product/4479) (0x1C & 0x1E)
-- [LSM303 Accelerometer & Magnetometer](https://www.adafruit.com/product/4413) (0x19 for accelerometer and 0x1E for magnetometer)
-- [LSM9DS0 9-axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [LSM303 Accelerometer/Magnetometer](https://www.adafruit.com/product/4413) (0x19 for accelerometer and 0x1E for magnetometer)
+- [LSM9DS0 9-Axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
 
 ## 0x1F
 
-- [MCP9808 temp sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
-- [FXOS8700 Accelerometer/Magnetometer](https://www.adafruit.com/product/3463) (0x1C, 0x1D, 0x1E or 0x1F)
+- [MCP9808 Temperature Sensor](https://www.adafruit.com/product/1782) (0x18 - 0x1F)
+- [FXOS8700 Accelerometer & Magnetometer](https://www.adafruit.com/product/3463) (0x1C, 0x1D, 0x1E or 0x1F)

--- a/0x20-0x2F.md
+++ b/0x20-0x2F.md
@@ -4,61 +4,61 @@
 
 - [FXAS21002 Gyroscope](https://www.adafruit.com/product/3463) (0x20 or 0x21)
 - [Chirp! Water Sensor](https://www.adafruit.com/product/1965) (0x20)
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x21
 
 - [FXAS21002 Gyroscope](https://www.adafruit.com/product/3463) (0x20 or 0x21)
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x22
 
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x23
 
 - [BH1750 Light Sensor](https://www.adafruit.com/product/4681) (0x23 or 0x5C)
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x24
 
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x25
 
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x26
 
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 - [MSA301 3-Axis Accelerometer](https://www.adafruit.com/product/4344) (0x26 only)
 
 ## 0x27
 
-- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x28
 
 - [BNO055 IMU](https://www.adafruit.com/product/2472) (0x28 or 0x29)
 - [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
-- [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
-- [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
+- [DS1841 Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
+- [DS3502 Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 - [TSL2591 Light Sensor](https://www.adafruit.com/product/1980) (0x29 and 0x28)
 
 ## 0x29
 
 - [BNO055 IMU](https://www.adafruit.com/product/2472) (0x28 or 0x29)
-- [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
-- [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
+- [DS1841 Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
+- [DS3502 Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 - [TCS34725 Color Sensor](https://www.adafruit.com/product/1334) (0x29 only)
 - [TSL2561 Light Sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
@@ -70,15 +70,15 @@
 ## 0x2A
 
 - [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
-- [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
-- [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
+- [DS1841 Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
+- [DS3502 Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x2B
 
 - [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
-- [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
-- [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
+- [DS1841 Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
+- [DS3502 Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x2C

--- a/0x20-0x2F.md
+++ b/0x20-0x2F.md
@@ -3,56 +3,56 @@
 ## 0x20
 
 - [FXAS21002 Gyroscope](https://www.adafruit.com/product/3463) (0x20 or 0x21)
-- [Chirp! Water sensor](https://www.adafruit.com/product/1965) (0x20)
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [Chirp! Water Sensor](https://www.adafruit.com/product/1965) (0x20)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x21
 
 - [FXAS21002 Gyroscope](https://www.adafruit.com/product/3463) (0x20 or 0x21)
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x22
 
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x23
 
 - [BH1750 Light Sensor](https://www.adafruit.com/product/4681) (0x23 or 0x5C)
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x24
 
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x25
 
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x26
 
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
-- [MSA301 Triple Axis Accelerometer](https://www.adafruit.com/product/4344) (0x26 only)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MSA301 3-Axis Accelerometer](https://www.adafruit.com/product/4344) (0x26 only)
 
 ## 0x27
 
-- [MCP23008 I2C GPIO expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
-- [MCP23017 I2C GPIO expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [MCP23008 I2C GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
+- [MCP23017 I2C GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
 
 ## 0x28
 
 - [BNO055 IMU](https://www.adafruit.com/product/2472) (0x28 or 0x29)
-- [CAP1188 8-channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
+- [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
 - [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
 - [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
-- [TSL2591 light sensor](https://www.adafruit.com/product/1980) (0x29 and 0x28)
+- [TSL2591 Light Sensor](https://www.adafruit.com/product/1980) (0x29 and 0x28)
 
 ## 0x29
 
@@ -60,35 +60,35 @@
 - [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
 - [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
-- [TCS34725 color sensor](https://www.adafruit.com/product/1334) (0x29 only)
-- [TSL2561 light sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
-- [TSL2591 light sensor](https://www.adafruit.com/product/1980) (0x29 and 0x28)
-- [VL53L0x ToF sensor](https://www.adafruit.com/product/3317) (0x29, software selectable)
-- [VL6180X ToF sensor](https://www.adafruit.com/product/3316) (0x29)
-- [CAP1188 8-channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D )
+- [TCS34725 Color Sensor](https://www.adafruit.com/product/1334) (0x29 only)
+- [TSL2561 Light Sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
+- [TSL2591 Light Sensor](https://www.adafruit.com/product/1980) (0x29 and 0x28)
+- [VL53L0x ToF Sensor](https://www.adafruit.com/product/3317) (0x29, software selectable)
+- [VL6180X ToF Sensor](https://www.adafruit.com/product/3316) (0x29)
+- [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D )
 
 ## 0x2A
 
-- [CAP1188 8-channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
+- [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
 - [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
 - [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x2B
 
-- [CAP1188 8-channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
+- [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
 - [DS1841 I2C Digital Logarithmic Potentiometer](https://www.adafruit.com/product/4570) (0x28-0x2B)
 - [DS3502 I2C Digital 10K Potentiometer](https://www.adafruit.com/product/4286) (0x28-0x2B)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x2C
 
-- [CAP1188 8-channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
+- [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x2D
 
-- [CAP1188 8-channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
+- [CAP1188 8-Channel Capacitive Touch](https://www.adafruit.com/product/1602) (0x28 - 0x2D)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x2E

--- a/0x30-0x3F.md
+++ b/0x30-0x3F.md
@@ -6,7 +6,7 @@
 
 ## 0x36
 
-- [Adafruit I2C QT Rotary Encoder with NeoPixel](https://www.adafruit.com/product/4991) (0x36 through 0x3D by using the jumpers on the back of the board)
+- [Adafruit Stemma QT Rotary Encoder with NeoPixel](https://www.adafruit.com/product/4991) (0x36 through 0x3D by using the jumpers on the back of the board)
 
 ## 0x38
 

--- a/0x30-0x3F.md
+++ b/0x30-0x3F.md
@@ -10,24 +10,24 @@
 
 ## 0x38
 
-- [AHT20 Humidity/Temp Sensor](https://www.adafruit.com/product/4566) (0x38 only)
-- DHT20 Humidity/Temp Sensor (0x38 only)
+- [AHT20 Humidity/Temperature Sensor](https://www.adafruit.com/product/4566) (0x38 only)
+- DHT20 Humidity/Temperature Sensor (0x38 only)
 - [VEML6070 UV Index](https://www.adafruit.com/product/2899) (0x38 and 0x39)
 - [FT6x06 Capacitive Touch Driver](https://www.adafruit.com/product/1947) (0x38 only)
 
 ## 0x39
 
 - [AS7341 Color Sensor](https://www.adafruit.com/product/4698) (0x39)
-- [TSL2561 light sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
-- [VEML6070 UV Index](https://www.adafruit.com/product/2899) (0x38 and 0x39)
+- [TSL2561 Light Sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
+- [VEML6070 UV Light Sensor](https://www.adafruit.com/product/2899) (0x38 and 0x39)
 - [APDS-9960 IR/Color/Proximity Sensor](https://www.adafruit.com/product/3595) (0x39 only)
 
 ## 0x3C
 
-- [SSD1305 monochrome OLED](https://www.adafruit.com/product/2720) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
-- [SSD1306 monochrome OLED](https://www.adafruit.com/product/938) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
+- [SSD1305 Monochrome OLED](https://www.adafruit.com/product/2720) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
+- [SSD1306 Monochrome OLED](https://www.adafruit.com/product/938) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
 
 ## 0x3D
 
-- [SSD1305 monochrome OLED](https://www.adafruit.com/product/2720) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
-- [SSD1306 monochrome OLED](https://www.adafruit.com/product/938) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
+- [SSD1305 Monochrome OLED](https://www.adafruit.com/product/2720) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)
+- [SSD1306 Monochrome OLED](https://www.adafruit.com/product/938) (0x3C or 0x3D, hardware selectable on some displays with a solder connection)

--- a/0x40-0x4F.md
+++ b/0x40-0x4F.md
@@ -4,149 +4,149 @@
 
 ## 0x40
 
-- [Si7021 Humidity/Temp sensor](https://www.adafruit.com/product/3251) (0x40 only)
-- [HTU21D-F Humidity/Temp Sensor](https://www.adafruit.com/product/1899) (0x40 only)
-- [HTU31D Humidity/Temp Sensor](https://www.adafruit.com/product/4832) (0x40 or 0x41)
-- [HDC1008 Humidity/Temp sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
-- [MS8607 Temp/Barometric/Humidity](https://www.adafruit.com/product/4716) (0x40 for Humidity and 0x76 for Barometric/Temperature)
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [PCA9685 16-channel PWM driver default address](https://www.adafruit.com/product/815) (0x40 - 0x7F)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [Si7021 Humidity/Temperature Sensor](https://www.adafruit.com/product/3251) (0x40 only)
+- [HTU21D-F Humidity/Temperature Sensor](https://www.adafruit.com/product/1899) (0x40 only)
+- [HTU31D Humidity/Temperature Sensor](https://www.adafruit.com/product/4832) (0x40 or 0x41)
+- [HDC1008 Humidity/Temperature Sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
+- [MS8607 Humidity/Temperature/Pressure Sensor](https://www.adafruit.com/product/4716) (0x40 for Humidity and 0x76 for Temperature/Pressure)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [PCA9685 16-Channel PWM Driver (default address)](https://www.adafruit.com/product/815) (0x40 - 0x7F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 
 ## 0x41
 
-- [HDC1008 Humidity/Temp sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
-- [HTU31D Humidity/Temp Sensor](https://www.adafruit.com/product/4832) (0x40 or 0x41)
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [HDC1008 Humidity/Temperature Sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
+- [HTU31D Humidity/Temperature Sensor](https://www.adafruit.com/product/4832) (0x40 or 0x41)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [STMPE610/STMPE811 Resistive Touch controller](https://www.adafruit.com/product/1571) (0x41 or 0x44)
+- [STMPE610/STMPE811 Resistive Touch Controller](https://www.adafruit.com/product/1571) (0x41 or 0x44)
 
 ## 0x42
 
-- [HDC1008 Humidity/Temp sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [HDC1008 Humidity/Temperature Sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 
 ## 0x43
 
-- [HDC1008 Humidity/Temp sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [HDC1008 Humidity/Temperature Sensor](https://www.adafruit.com/product/2635) (0x40, 0x41, 0x42 or 0x43)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 
 ## 0x44
 
-- [SHT40 Humidity/Temp sensor](https://www.adafruit.com/product/4885) (0x44)
-- [SHT31 Humidity/Temp sensor](https://www.adafruit.com/product/2857) (0x44 or 0x45 selectable)
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [SHT40 Humidity/Temperature Sensor](https://www.adafruit.com/product/4885) (0x44)
+- [SHT31 Humidity/Temperature Sensor](https://www.adafruit.com/product/2857) (0x44 or 0x45 selectable)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
 - ISL29125 Color Sensor (0x44 only)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 - [STMPE610/STMPE811 Resistive Touch controller](https://www.adafruit.com/product/1571) (0x41 or 0x44)
 
 ## 0x45
 
-- [SHT31 Humidity/Temp sensor](https://www.adafruit.com/product/2857) (0x44 or 0x45 selectable)
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [SHT31 Humidity/Temperature Sensor](https://www.adafruit.com/product/2857) (0x44 or 0x45 selectable)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 
 ## 0x46
 
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 
 ## 0x47
 
-- [TMP007 IR Temperature sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
-- [TMP006 IR Temperature sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [TMP007 IR Temperature Sensor](https://www.adafruit.com/product/2023) (0x40 - 0x47)
+- [TMP006 IR Temperature Sensor](https://www.adafruit.com/product/1296) (0x40 - 0x47)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 
 ## 0x48
 
-- [ADS1115 4-channel 16-bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
-- [ADT7410 Temp sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [ADS1115 4-channel 16-Bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
+- [ADT7410 Temperature Sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 - [PN532 NFC/RFID reader](https://www.adafruit.com/product/364) (0x48 only)
-- TMP102 Temperature sensor (0x48 0x49 0x4A or 0x4B)
-- [TMP117 Temperature sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
+- TMP102 Temperature Sensor (0x48 0x49 0x4A or 0x4B)
+- [TMP117 Temperature Sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
 
 ## 0x49
 
-- [ADS1115 4-channel 16-bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
-- [ADT7410 Temp sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
-- [AS7262 Light/Color sensor](https://www.adafruit.com/product/3779) (0x49)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [ADS1115 4-Channel 16-Bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
+- [ADT7410 Temperature Sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
+- [AS7262 Light/Color Sensor](https://www.adafruit.com/product/3779) (0x49)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
-- [TSL2561 light sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
-- TMP102 Temperature sensor (0x48 0x49 0x4A or 0x4B)
-- [TMP117 Temperature sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
+- [TSL2561 Light Sensor](https://www.adafruit.com/product/439) (0x29, 0x39 or 0x49)
+- TMP102 Temperature Sensor (0x48 0x49 0x4A or 0x4B)
+- [TMP117 Temperature Sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
 
 ## 0x4A
 
-- [ADS1115 4-channel 16-bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
-- [ADT7410 Temp sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
+- [ADS1115 4-channel 16-Bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
+- [ADT7410 Temperature Sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
 - [BNO085 9-DoF IMU](https://www.adafruit.com/product/4754) (0x4A or 0x4B)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
-- TMP102 Temperature sensor (0x48 0x49 0x4A or 0x4B)
-- [TMP117 Temperature sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
+- TMP102 Temperature Sensor (0x48 0x49 0x4A or 0x4B)
+- [TMP117 Temperature Sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
 
 ## 0x4B
 
-- [ADS1115 4-channel 16-bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
-- [ADT7410 Temp sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
+- [ADS1115 4-channel 16-Bit ADC](https://www.adafruit.com/product/1085) (0x48 0x49 0x4A or 0x4B)
+- [ADT7410 Temperature Sensor](https://www.adafruit.com/product/4089) (0x48 0x49 0x4A or 0x4B)
 - [BNO085 9-DoF IMU](https://www.adafruit.com/product/4754) (0x4A or 0x4B)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
-- TMP102 Temperature sensor (0x48 0x49 0x4A or 0x4B)
-- [TMP117 Temperature sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
+- TMP102 Temperature Sensor (0x48 0x49 0x4A or 0x4B)
+- [TMP117 Temperature Sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
 
 ## 0x4C
 
 - [EMC2101 Fan Controller](https://www.adafruit.com/product/4808) (0x4C)
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x30-0x37, 0x48-0x4F)
 
 ## 0x4D
 
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x4E
 
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
 
 ## 0x4F
 
-- [INA219 High-Side DC Current/Voltage sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
+- [INA219 High-Side DC Current/Voltage Sensor](https://www.adafruit.com/product/904) (0x40 - 0x4F)
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
-- [PCF8591 Quad 8-bit ADC + 8-bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
+- [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)

--- a/0x50-0x5F.md
+++ b/0x50-0x5F.md
@@ -5,15 +5,15 @@
 
 ## 0x50
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x51
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x52
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 - [Nintendo Nunchuck Controller](https://www.adafruit.com/product/342) (0x52 only)
 
 ## 0x53
@@ -21,29 +21,29 @@
 - [ADXL343 3-Axis Accelerometer](https://www.adafruit.com/product/4097) (0x1D or 0x53)
 - [ADXL345 3-Axis Accelerometer](https://www.adafruit.com/product/1231) (0x1D or 0x53)
 - [LTR390 UV Sensor](https://www.adafruit.com/product/4831) (0x53)
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x54
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x55
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x56
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x57
 
-- [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
+- [MB85RC FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 - MAX3010x Pulse & Oximetry Sensor (0x57)
 
 ## 0x58
 
 - [AW9523 GPIO Expander and LED Driver](https://www.adafruit.com/product/4886) (0x58 - 0x5B)
-- [TPA2016 I2C-Controlled Amplifier](https://www.adafruit.com/product/1712) (0x58 only)
+- [TPA2016 Class-D Audio Amplifier](https://www.adafruit.com/product/1712) (0x58 only)
 - [SGP30 Gas Sensor](https://www.adafruit.com/product/3709) (0x58 only)
 
 ## 0x59

--- a/0x50-0x5F.md
+++ b/0x50-0x5F.md
@@ -14,13 +14,13 @@
 ## 0x52
 
 - [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
-- [Nintendo Nunchuck controller](https://www.adafruit.com/product/342) (0x52 only)
+- [Nintendo Nunchuck Controller](https://www.adafruit.com/product/342) (0x52 only)
 
 ## 0x53
 
-- [ADXL343 3-axis accelerometer](https://www.adafruit.com/product/4097) (0x1D or 0x53)
-- [ADXL345 3-axis accelerometer](https://www.adafruit.com/product/1231) (0x1D or 0x53)
-- [LTR390 UV sensor](https://www.adafruit.com/product/4831) (0x53)
+- [ADXL343 3-Axis Accelerometer](https://www.adafruit.com/product/4097) (0x1D or 0x53)
+- [ADXL345 3-Axis Accelerometer](https://www.adafruit.com/product/1231) (0x1D or 0x53)
+- [LTR390 UV Sensor](https://www.adafruit.com/product/4831) (0x53)
 - [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
 
 ## 0x54
@@ -38,12 +38,12 @@
 ## 0x57
 
 - [MB85RC I2C FRAM](https://www.adafruit.com/product/1895) (0x50 - 0x57)
-- MAX3010x Pulse & Oximetry sensor (0x57)
+- MAX3010x Pulse & Oximetry Sensor (0x57)
 
 ## 0x58
 
 - [AW9523 GPIO Expander and LED Driver](https://www.adafruit.com/product/4886) (0x58 - 0x5B)
-- [TPA2016 I2C-controlled Amplifier](https://www.adafruit.com/product/1712) (0x58 only)
+- [TPA2016 I2C-Controlled Amplifier](https://www.adafruit.com/product/1712) (0x58 only)
 - [SGP30 Gas Sensor](https://www.adafruit.com/product/3709) (0x58 only)
 
 ## 0x59
@@ -54,27 +54,27 @@
 ## 0x5A
 
 - [AW9523 GPIO Expander and LED Driver](https://www.adafruit.com/product/4886) (0x58 - 0x5B)
-- [MPR121 12-point capacitive touch sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
-- [CCS811 VOC sensor](https://www.adafruit.com/product/3566) (0x5A or 0x5B)
-- [MLX9061x IR temperature sensor](https://www.adafruit.com/product/1747) (0x5A only)
+- [MPR121 12-Point Capacitive Touch Sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
+- [CCS811 VOC Sensor](https://www.adafruit.com/product/3566) (0x5A or 0x5B)
+- [MLX9061x IR Temperature Sensor](https://www.adafruit.com/product/1747) (0x5A only)
 - [DRV2605 Haptic Motor Driver](https://www.adafruit.com/product/2305) (0x5A only)
 
 ## 0x5B
 
 - [AW9523 GPIO Expander and LED Driver](https://www.adafruit.com/product/4886) (0x58 - 0x5B)
-- [MPR121 12-point capacitive touch sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
-- [CCS811 VOC sensor](https://www.adafruit.com/product/3566) (0x5A or 0x5B)
+- [MPR121 12-Point Capacitive Touch Sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
+- [CCS811 VOC Sensor](https://www.adafruit.com/product/3566) (0x5A or 0x5B)
 
 ## 0x5C
 
-- [AM2315 Humidity/Temp sensor](https://www.adafruit.com/product/1293) (0x5C only)
-- [AM2320 Humidity/Temp sensor](https://www.adafruit.com/product/3721) (0x5C only)
+- [AM2315 Humidity/Temp Sensor](https://www.adafruit.com/product/1293) (0x5C only)
+- [AM2320 Humidity/Temp Sensor](https://www.adafruit.com/product/3721) (0x5C only)
 - [BH1750 Light Sensor](https://www.adafruit.com/product/4681) (0x23 or 0x5C)
 - [LPS22 Pressure Sensor](https://www.adafruit.com/product/4633) (0x5C, 0x5D)
 - [LPS25 Pressure Sensor](https://www.adafruit.com/product/4530) (0x5C, 0x5D)
 - [LPS33HW Ported Pressure Sensor](https://www.adafruit.com/product/4414) (0x5C, 0x5D)
 - [LPS35HW Pressure Sensor](https://www.adafruit.com/product/4258) (0x5C, 0x5D)
-- [MPR121 12-point capacitive touch sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
+- [MPR121 12-Point Capacitive Touch Sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
 
 ## 0x5D
 
@@ -82,12 +82,12 @@
 - [LPS25 Pressure Sensor](https://www.adafruit.com/product/4530) (0x5C, 0x5D)
 - [LPS33HW Ported Pressure Sensor](https://www.adafruit.com/product/4414) (0x5C, 0x5D)
 - [LPS35HW Pressure Sensor](https://www.adafruit.com/product/4258) (0x5C, 0x5D)
-- [MPR121 12-point capacitive touch sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
+- [MPR121 12-Point Capacitive Touch Sensor](https://www.adafruit.com/product/1982) (0x5A, 0x5B, 0x5C, 0x5D)
 
 ## 0x5E
 
-- [TLV493D triple-axis Magnetometer](https://www.adafruit.com/product/4366) (0x5E)
+- [TLV493D 3-Axis Magnetometer](https://www.adafruit.com/product/4366) (0x5E)
 
 ## 0x5F
 
-- [HTS221 Humidity/Temp Sensor](https://www.adafruit.com/product/4535) (0x5F)
+- [HTS221 Humidity/Temperature Sensor](https://www.adafruit.com/product/4535) (0x5F)

--- a/0x60-0x6F.md
+++ b/0x60-0x6F.md
@@ -6,52 +6,52 @@
 
 - [ATECC608 Cryptographic Co-Processor](https://www.adafruit.com/product/4314) (0x60)
 - [MCP4728 Quad DAC](https://adafruit.com/product/4470) (0x60 only)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 - [MPL115A2 Barometric Pressure](https://www.adafruit.com/product/992) (0x60 only)
 - [MPL3115A2 Barometric Pressure](https://www.adafruit.com/product/1893) (0x60 only)
 - [Si5351A Clock Generator](https://www.adafruit.com/product/2045) (0x60 or 0x61)
 - [Si1145 Light/IR Sensor](https://www.adafruit.com/product/1777) (0x60 only)
-- MCP4725A0 12-bit DAC (0x60 or 0x61)
-- TEA5767 Radio receiver (0x60 only)
-- [VCNL4040 Proximity and Ambient Light sensor](https://www.adafruit.com/product/4161) (0x60 only)
+- MCP4725A0 12-Bit DAC (0x60 or 0x61)
+- TEA5767 Radio Receiver (0x60 only)
+- [VCNL4040 Proximity and Ambient Light Sensor](https://www.adafruit.com/product/4161) (0x60 only)
 
 ## 0x61
 
-- MCP4725A0 12-bit DAC (0x60 or 0x61)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- MCP4725A0 12-Bit DAC (0x60 or 0x61)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 - [Si5351A Clock Generator](https://www.adafruit.com/product/2045) (0x60 or 0x61)
-- [SCD30 Humidity/Temp/Gas sensor](https://www.adafruit.com/product/4867) (0x61)
+- [SCD30 Humidity/Temperature/CO2 Sensor](https://www.adafruit.com/product/4867) (0x61)
 
 ## 0x62
 
-- [MCP4725A1 12-bit DAC](https://www.adafruit.com/product/935) (0x62 or 0x63)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- [MCP4725A1 12-Bit DAC](https://www.adafruit.com/product/935) (0x62 or 0x63)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 
 ## 0x63
 
-- [MCP4725A1 12-bit DAC](https://www.adafruit.com/product/935) (0x62 or 0x63)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- [MCP4725A1 12-Bit DAC](https://www.adafruit.com/product/935) (0x62 or 0x63)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 - [Si4713 FM Transmitter with RDS](https://www.adafruit.com/product/1958) (0x11 or 0x63)
 
 ## 0x64
 
-- MCP4725A2 12-bit DAC (0x64 or 0x65)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- MCP4725A2 12-Bit DAC (0x64 or 0x65)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 
 ## 0x65
 
-- MCP4725A2 12-bit DAC (0x64 or 0x65)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- MCP4725A2 12-Bit DAC (0x64 or 0x65)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 
 ## 0x66
 
-- MCP4725A3 12-bit DAC (0x66 or 0x67)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- MCP4725A3 12-Bit DAC (0x66 or 0x67)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 
 ## 0x67
 
-- MCP4725A3 12-bit DAC (0x66 or 0x67)
-- [MCP9600 Temp Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
+- MCP4725A3 12-Bit DAC (0x66 or 0x67)
+- [MCP9600 Temperature Sensor](https://www.adafruit.com/product/4101) (0x60 - 0x67)
 
 ## 0x68
 
@@ -60,32 +60,32 @@ This address is really popular with real time clocks, almost all of them use 0x6
 - [AMG8833 IR Thermal Camera Breakout](https://www.adafruit.com/product/3538) (0x68 or 0x69)
 - [DS1307 RTC](https://www.adafruit.com/product/3296) (0x68 only)
 - [DS3231 RTC](https://www.adafruit.com/product/3013) (0x68 only)
-- [ICM-20649 Accel+Gyro](https://adafruit.com/product/4464) (0x68 or 0x69)
-- ITG3200 Gyro (0x68 or 0x69)
+- [ICM-20649 Accelerometer + Gyroscope](https://adafruit.com/product/4464) (0x68 or 0x69)
+- ITG3200 Gyroscope (0x68 or 0x69)
 - MPU-9250 9-DoF IMU (0x68 or 0x69)
-- MPU-60X0 Accel+Gyro (0x68 or 0x69)
+- MPU-60X0 Accelerometer + Gyroscope (0x68 or 0x69)
 - [PCF8523 RTC](https://www.adafruit.com/product/3295) (0x68 only)
 
 ## 0x69
 
 - [AMG8833 IR Thermal Camera Breakout](https://www.adafruit.com/product/3538) (0x68 or 0x69)
-- [ICM-20649 Accel+Gyro](https://adafruit.com/product/4464) (0x68 or 0x69)
-- MPU-9250 (0x68 or 0x69)
-- MPU-60X0 Accel+Gyro (0x68 or 0x69)
-- ITG3200 Gyro (0x68 or 0x69)
+- [ICM-20649 Accelerometer + Gyroscope](https://adafruit.com/product/4464) (0x68 or 0x69)
+- MPU-9250 9-DoF IMU (0x68 or 0x69)
+- MPU-60X0 Accelerometer + Gyroscope (0x68 or 0x69)
+- ITG3200 Gyroscope (0x68 or 0x69)
 
 ## 0x6A
 
-- [ICM330DHC 6-axis IMU](https://www.adafruit.com/product/4502) (0x6A or 0x6B)
-- [L3GD20H gyroscope](https://www.adafruit.com/product/1714) (0x6A or 0x6B)
-- [LSM6DS33 6-axis IMU](https://www.adafruit.com/product/4480) (0x6A or 0x6B)
-- [LSM6DSOX 6-axis IMU](https://adafruit.com/product/4438) (0x6A or 0x6B)
-- [LSM9DS0 9-axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
+- [ICM330DHC 6-Axis IMU](https://www.adafruit.com/product/4502) (0x6A or 0x6B)
+- [L3GD20H Gyroscope](https://www.adafruit.com/product/1714) (0x6A or 0x6B)
+- [LSM6DS33 6-Axis IMU](https://www.adafruit.com/product/4480) (0x6A or 0x6B)
+- [LSM6DSOX 6-Axis IMU](https://adafruit.com/product/4438) (0x6A or 0x6B)
+- [LSM9DS0 9-Axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
 
 ## 0x6B
 
-- [ICM330DHC 6-axis IMU](https://www.adafruit.com/product/4502) (0x6A or 0x6B)
-- [L3GD20H gyroscope](https://www.adafruit.com/product/1714) (0x6A or 0x6B)
-- [LSM6DS33 6-axis IMU](https://www.adafruit.com/product/4480) (0x6A or 0x6B)
-- [LSM6DSOX 6-axis IMU](https://adafruit.com/product/4438) (0x6A or 0x6B)
-- [LSM9DS0 9-axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)
+- [ICM330DHC 6-Axis IMU](https://www.adafruit.com/product/4502) (0x6A or 0x6B)
+- [L3GD20H Gyroscope](https://www.adafruit.com/product/1714) (0x6A or 0x6B)
+- [LSM6DS33 6-Axis IMU](https://www.adafruit.com/product/4480) (0x6A or 0x6B)
+- [LSM6DSOX 6-Axis IMU](https://adafruit.com/product/4438) (0x6A or 0x6B)
+- [LSM9DS0 9-Axis IMU](https://www.adafruit.com/product/2021) (0x1D or 0x1E for Accel/Mag, 0x6A or 0x6B for Gyro)

--- a/0x70-0x7F.md
+++ b/0x70-0x7F.md
@@ -75,19 +75,19 @@
 
 ## 0x78
 
-- Reserved for 10-bit I2C
+- Reserved for 10-bit I2C addressing
 
 ## 0x79
 
-- Reserved for 10-bit I2C
+- Reserved for 10-bit I2C addressing
 
 ## 0x7A
 
-- Reserved for 10-bit I2C
+- Reserved for 10-bit I2C addressing
 
 ## 0x7B
 
-- Reserved for 10-bit I2C Addressing
+- Reserved for 10-bit I2C addressing
 
 ## 0x7C
 

--- a/0x70-0x7F.md
+++ b/0x70-0x7F.md
@@ -91,15 +91,15 @@
 
 ## 0x7C
 
-- Reserved for Future Purposes
+- Reserved for future purposes
 
 ## 0x7D
 
-- Reserved for Future Purposes
+- Reserved for future purposes
 
 ## 0x7E
 
-- Reserved for Future Purposes
+- Reserved for future purposes
 
 ## 0x7F
 


### PR DESCRIPTION
This PR:

- Changes all device descriptions to title case;
- Changes other text e.g. "reserved for future use" to sentence case;
- Removes references to "I2C" from device names since all devices in this list are I2C;
  - An exception is "I2C Multiplexer" because removing "I2C" makes its function unclear.
- Makes a few minor changes with the use of "&" and "/" in the names of multi-function sensors.

Closes #7.