### PR TITLE
Note that SAMD can't do low bus speeds; add AGS20MA to troublesome chips

### DIFF
--- a/troublesome_chips.md
+++ b/troublesome_chips.md
@@ -3,16 +3,17 @@
 Some sensors or chips have non-standard behavior that causes issues when
 trying to use I2C. Here's a few of the ones to watch for
 
-- ATECCx08 - Use slow-speed I2C to get out of sleep mode
-- BNO055 - Clock stretching, and sometimes needs to be reset
-- CCS811 - Clock stretching
+- AGS20MA - Use a bus speed of 20-30 kHz.
+- ATECCx08 - Use slow-speed I2C to get out of sleep mode.
+- BNO055 - Uses clock stretching, and sometimes needs to be reset.
+- CCS811 - Uses clock stretching.
 - LC709203F - Repeated start, clock stretching, sleep mode
-- MCP9600 (date codes 1845 or before) - bug: duplicate data from register
-  reads, perhaps due to clock stretching
+- MCP9600 (date codes 1845 or before) - bug: duplicate data from register.
+  reads, perhaps due to clock stretching.
 - MCP9600, MCP9601 - Repeated start, clock stretching. Often will not
   respond to zero-length writes, so scanning the I2C bus to find the
   device can fail.
-- PN532 - Clock stretching
+- PN532 - Clock stretching.
 
 If you're using Raspberry Pi with these chips, check out our
 [guide on how to work-around clock stretching](https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/i2c-clock-stretching).
@@ -20,4 +21,4 @@ If you're using Raspberry Pi with these chips, check out our
 # Troublesome microcontrollers:
 
 - MicroChip Atmel SAMD21, SAMx5x - I2C bus frequency below 95 kHz not available when I2Cperipheral is drive with a 48 MHz clock,
-which is typical. CircuitPython checks for out-of-range bus frequencies.
+  which is typical. CircuitPython checks for out-of-range bus frequencies.

--- a/troublesome_chips.md
+++ b/troublesome_chips.md
@@ -3,16 +3,21 @@
 Some sensors or chips have non-standard behavior that causes issues when
 trying to use I2C. Here's a few of the ones to watch for
 
-- BNO055 - Clock stretching, and sometimes needs to be reset
 - ATECCx08 - Use slow-speed I2C to get out of sleep mode
+- BNO055 - Clock stretching, and sometimes needs to be reset
+- CCS811 - Clock stretching
+- LC709203F - Repeated start, clock stretching, sleep mode
 - MCP9600 (date codes 1845 or before) - bug: duplicate data from register
   reads, perhaps due to clock stretching
 - MCP9600, MCP9601 - Repeated start, clock stretching. Often will not
   respond to zero-length writes, so scanning the I2C bus to find the
   device can fail.
 - PN532 - Clock stretching
-- CCS811 - Clock stretching
-- LC709203F - Repeated start, clock stretching, sleep mode
 
 If you're using Raspberry Pi with these chips, check out our
 [guide on how to work-around clock stretching](https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/i2c-clock-stretching).
+
+# Troublesome microcontrollers:
+
+- MicroChip Atmel SAMD21, SAMx5x - I2C bus frequency below 95 kHz not available when I2Cperipheral is drive with a 48 MHz clock,
+which is typical. CircuitPython checks for out-of-range bus frequencies.


### PR DESCRIPTION
Also alphabetized troublesome chip list and did some copy-editing.