### PR TITLE
Fix the default address of the PN532 board.

### DIFF
--- a/0x20-0x2F.md
+++ b/0x20-0x2F.md
@@ -28,6 +28,7 @@
 
 - [MCP23008 GPIO Expander](https://www.adafruit.com/product/292) (0x20 - 0x27)
 - [MCP23017 GPIO Expander](https://www.adafruit.com/product/732) (0x20 - 0x27)
+- [PN532 NFC/RFID reader](https://www.adafruit.com/product/364) (0x24 only, unless manually configured)
 
 ## 0x25
 

--- a/0x40-0x4F.md
+++ b/0x40-0x4F.md
@@ -83,7 +83,6 @@
 - [INA260 Precision DC Current/Power Sensor](https://www.adafruit.com/product/4226) (0x40 - 0x4F)
 - [PCF8591 Quad 8-Bit ADC + 8-Bit DAC](https://www.adafruit.com/product/4648) (0x48 - 0x4F)
 - [PCT2075 Temperature Sensor](https://www.adafruit.com/product/4369) (0x28-0x2E, 0x48-0x4F, 0x70-0x77)
-- [PN532 NFC/RFID reader](https://www.adafruit.com/product/364) (0x48 only)
 - TMP102 Temperature Sensor (0x48 0x49 0x4A or 0x4B)
 - [TMP117 Temperature Sensor](https://www.adafruit.com/product/4821) (0x48 0x49 0x4A or 0x4B)
 


### PR DESCRIPTION
The confusion probably comes from that the address must be written as 0x48 to the board, but its lowest bit is ignored.

I’m also adding a mention that the address can actually be reconfigured.