### PR TITLE
Add AM2320 to troublesome chips

### DIFF
--- a/troublesome_chips.md
+++ b/troublesome_chips.md
@@ -15,6 +15,7 @@ trying to use I2C. Here's a few of the ones to watch for
   respond to zero-length writes, so scanning the I2C bus to find the
   device can fail.
 - PN532 - Clock stretching.
+- AM2320 - Automatic sleep behavior causes unreliable scanning.
 
 If you're using Raspberry Pi with these chips, check out our
 [guide on how to work-around clock stretching](https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/i2c-clock-stretching).

--- a/troublesome_chips.md
+++ b/troublesome_chips.md
@@ -4,6 +4,7 @@ Some sensors or chips have non-standard behavior that causes issues when
 trying to use I2C. Here's a few of the ones to watch for
 
 - AGS20MA - Use a bus speed of 20-30 kHz.
+- AM2320 - Automatic sleep behavior causes unreliable scanning.
 - ATECCx08 - Use slow-speed I2C to get out of sleep mode.
 - BNO055 - Uses clock stretching, violates I2C protocol timing in some cases, and sometimes needs to be reset. Does not work well on i.MX RT10xx chips. Does not work well with ESP32, ESP32-S3 before ESP-IDF 5.3.2. Use CircuitPython 9.2.2 or later.
 - BNO085 - Uses clock stretching, violates I2C protocol timing in some cases, and sometimes needs to be reset. Does not work well on i.MX RT10xx chips, ESP32, ESP32-S3.
@@ -15,7 +16,6 @@ trying to use I2C. Here's a few of the ones to watch for
   respond to zero-length writes, so scanning the I2C bus to find the
   device can fail.
 - PN532 - Clock stretching.
-- AM2320 - Automatic sleep behavior causes unreliable scanning.
 
 If you're using Raspberry Pi with these chips, check out our
 [guide on how to work-around clock stretching](https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/i2c-clock-stretching).


### PR DESCRIPTION
Related thread:
https://forums.adafruit.com/viewtopic.php?t=221242

This is most likely related to the automatic sleep behavior of the AM2320 mentioned in the datasheet.

It can show up eventually if you spam scan:
```py
Adafruit CircuitPython 10.0.3 on 2025-10-17; Adafruit Feather M0 Express with samd21g18
>>> import board
>>> import busio
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> i2c.try_lock()
True
>>> i2c.scan()
[]
>>> i2c.scan()
[]
>>> i2c.scan()
[92]
>>> i2c.scan()
[]
>>> 
```

But behavior is still Troublesome©®